### PR TITLE
3 review noreferrer attributes

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@
         <p class="hero-subtitle">Estudiante de Programación · La Plata, Buenos Aires. Argentina</p>
 
         <div class="social-links">
-          <a href="https://www.linkedin.com/in/paula-giudici" target="_blank" rel="noopener" class="social-btn">
+          <a href="https://www.linkedin.com/in/paula-giudici" target="_blank" rel="noopener noreferrer" class="social-btn">
             <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor">
               <path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"/>
               <rect x="2" y="9" width="4" height="12"/>
@@ -56,7 +56,7 @@
             </svg>
             LinkedIn
           </a>
-          <a href="https://github.com/Paulagiudici" target="_blank" rel="noopener" class="social-btn social-btn--ghost">
+          <a href="https://github.com/Paulagiudici" target="_blank" rel="noopener noreferrer" class="social-btn social-btn--ghost">
             <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"/>
             </svg>


### PR DESCRIPTION
Este PR revisa y corrige los atributos rel en enlaces externos que usan target="_blank" en CV_TUP/index.html.

Qué se cambió
Se añadió rel="noopener noreferrer" a los enlaces externos con target="_blank":
LinkedIn
GitHub
Otros enlaces externos presentes en el HTML
<img width="1061" height="67" alt="noreferrer" src="https://github.com/user-attachments/assets/a86db0cf-8341-40da-8d7e-b78ff0b0cc9a" />
close #3 